### PR TITLE
Refactor API helpers for easier extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ company data or **Sandbox** when testing against Intuit's sandbox API.
 - `templates/` – Jinja2 templates for all pages.
 - `build-scripts/` – PowerShell and Inno Setup scripts for Windows builds.
 
+## API Connectors
+
+Utility modules in `utils/` provide lightweight clients for external services:
+
+- `ShopifyClient` – e-commerce order and catalog sync
+- `QBOClient` – QuickBooks Online transactions
+- `HubSpotClient` – website traffic analytics
+
+Each client exposes a `fetch_*` method and simple wrappers so new providers can
+follow the same pattern.
+
 ## Programmatic Reports
 
 Helper functions in `app.py` expose the underlying report data for integration into other Python code:

--- a/utils/hubspot_api.py
+++ b/utils/hubspot_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import json
 import os
 import time
@@ -41,6 +43,84 @@ def _normalize_hubspot_source(src):
     return HUBSPOT_SOURCE_MAP.get(key)
 
 
+@dataclass
+class HubSpotClient:
+    """Simple HubSpot API client."""
+
+    token: str
+
+    def fetch_traffic_data(
+        self,
+        start_year: int = 2021,
+        end_year: int = 2025,
+        *,
+        retries: int = 3,
+        cache_dir: str | None = None,
+    ) -> pd.DataFrame:
+        """Return monthly HubSpot traffic analytics for a date range."""
+        url = "https://api.hubapi.com/analytics/v2/reports/sources/monthly"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        params = {
+            "start": f"{start_year:04d}0101",
+            "end": f"{end_year:04d}1231",
+        }
+
+        offset = None
+        rows = []
+        page = 0
+        while True:
+            if offset is not None:
+                params["offset"] = offset
+            attempt = 0
+            while True:
+                try:
+                    resp = requests.get(url, headers=headers, params=params, timeout=15)
+                    add_api_response(
+                        "fetch_hubspot", resp.status_code, resp.text[:2000]
+                    )
+                    if resp.status_code == 429 and attempt < retries - 1:
+                        time.sleep(2**attempt)
+                        attempt += 1
+                        continue
+                    resp.raise_for_status()
+                except Exception:
+                    if attempt >= retries - 1:
+                        raise
+                    time.sleep(2**attempt)
+                    attempt += 1
+                    continue
+                break
+
+            payload = resp.json()
+            if cache_dir:
+                os.makedirs(cache_dir, exist_ok=True)
+                with open(
+                    os.path.join(cache_dir, f"hubspot_{page:03d}.json"), "w"
+                ) as f:
+                    json.dump(payload, f)
+            for row in payload.get("data", []):
+                source = _normalize_hubspot_source(row.get("source"))
+                if not source:
+                    continue
+                year = int(row.get("year"))
+                month = int(row.get("month"))
+                rows.append(
+                    {
+                        "year": year,
+                        "month": datetime(year, month, 1).strftime("%b"),
+                        "source": source,
+                        "sessions": int(row.get("sessions")),
+                        "bounce_rate": float(row.get("bounce_rate")),
+                        "avg_time_min": float(row.get("avg_time")) / 60,
+                    }
+                )
+            offset = payload.get("offset")
+            page += 1
+            if not offset:
+                break
+        return pd.DataFrame(rows)
+
+
 def fetch_hubspot_traffic_data(
     token,
     start_year: int = 2021,
@@ -49,61 +129,11 @@ def fetch_hubspot_traffic_data(
     retries: int = 3,
     cache_dir: str | None = None,
 ):
-    """Return monthly HubSpot traffic analytics for a date range."""
-    url = "https://api.hubapi.com/analytics/v2/reports/sources/monthly"
-    headers = {"Authorization": f"Bearer {token}"}
-    params = {
-        "start": f"{start_year:04d}0101",
-        "end": f"{end_year:04d}1231",
-    }
-
-    offset = None
-    rows = []
-    page = 0
-    while True:
-        if offset is not None:
-            params["offset"] = offset
-        attempt = 0
-        while True:
-            try:
-                resp = requests.get(url, headers=headers, params=params, timeout=15)
-                add_api_response("fetch_hubspot", resp.status_code, resp.text[:2000])
-                if resp.status_code == 429 and attempt < retries - 1:
-                    time.sleep(2**attempt)
-                    attempt += 1
-                    continue
-                resp.raise_for_status()
-            except Exception:
-                if attempt >= retries - 1:
-                    raise
-                time.sleep(2**attempt)
-                attempt += 1
-                continue
-            break
-
-        payload = resp.json()
-        if cache_dir:
-            os.makedirs(cache_dir, exist_ok=True)
-            with open(os.path.join(cache_dir, f"hubspot_{page:03d}.json"), "w") as f:
-                json.dump(payload, f)
-        for row in payload.get("data", []):
-            source = _normalize_hubspot_source(row.get("source"))
-            if not source:
-                continue
-            year = int(row.get("year"))
-            month = int(row.get("month"))
-            rows.append(
-                {
-                    "year": year,
-                    "month": datetime(year, month, 1).strftime("%b"),
-                    "source": source,
-                    "sessions": int(row.get("sessions")),
-                    "bounce_rate": float(row.get("bounce_rate")),
-                    "avg_time_min": float(row.get("avg_time")) / 60,
-                }
-            )
-        offset = payload.get("offset")
-        page += 1
-        if not offset:
-            break
-    return pd.DataFrame(rows)
+    """Compatibility wrapper for fetching HubSpot traffic data."""
+    client = HubSpotClient(token)
+    return client.fetch_traffic_data(
+        start_year=start_year,
+        end_year=end_year,
+        retries=retries,
+        cache_dir=cache_dir,
+    )

--- a/utils/qbo_api.py
+++ b/utils/qbo_api.py
@@ -2,33 +2,127 @@
 
 from __future__ import annotations
 
-import requests
+from dataclasses import dataclass
+
 import pandas as pd
+import requests
+
+
+@dataclass
+class QBOClient:
+    """Simple QuickBooks Online API client."""
+
+    client_id: str
+    client_secret: str
+    refresh_token: str
+    realm_id: str
+    environment: str = "prod"
+
+    def refresh_access(self) -> tuple[str | None, str | None]:
+        """Return a new access token and refresh token."""
+        auth = requests.auth.HTTPBasicAuth(self.client_id, self.client_secret)
+        data = {"grant_type": "refresh_token", "refresh_token": self.refresh_token}
+        resp = requests.post(
+            "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+            auth=auth,
+            data=data,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        tokens = resp.json()
+        self.refresh_token = tokens.get("refresh_token")
+        return tokens.get("access_token"), self.refresh_token
+
+    def api_url(self, path: str) -> str:
+        """Return the API base URL."""
+        base = (
+            "https://sandbox-quickbooks.api.intuit.com"
+            if self.environment == "sandbox"
+            else "https://quickbooks.api.intuit.com"
+        )
+        return f"{base}/v3/company/{self.realm_id}/{path}"
+
+    def fetch_transactions(
+        self,
+        *,
+        doc_type: str = "SalesReceipt",
+        start_pos: int = 1,
+        item_map: dict | None = None,
+        fetch_lists: bool = False,
+    ):
+        """Return transaction data from QuickBooks."""
+        access_token, new_refresh = self.refresh_access()
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        query = f"select * from {doc_type} startposition {start_pos} maxresults 1000"
+        url = self.api_url("query")
+        resp = requests.post(url, headers=headers, json={"query": query}, timeout=15)
+        resp.raise_for_status()
+        payload = resp.json()
+        docs = payload.get("QueryResponse", {}).get(doc_type, [])
+
+        rows = []
+        lines = []
+        for doc in docs:
+            created = doc.get("TxnDate")
+            doc_id = doc.get("Id") or doc.get("DocNumber")
+            for idx, line in enumerate(doc.get("Line", [])):
+                detail = line.get("SalesItemLineDetail", {})
+                rows.append(
+                    {
+                        "created_at": created,
+                        "sku": detail.get("ItemRef", {}).get("value"),
+                        "description": line.get("Description"),
+                        "quantity": detail.get("Qty"),
+                        "price": detail.get("UnitPrice"),
+                        "total": line.get("Amount"),
+                    }
+                )
+                lines.append({"doc_id": doc_id, "line_num": idx, "data": line})
+
+        df = pd.DataFrame(rows)
+        next_pos = start_pos + 1000 if len(docs) == 1000 else None
+        item_map = item_map or {}
+        return (
+            df,
+            [],
+            docs,
+            lines,
+            new_refresh,
+            headers,
+            item_map,
+            next_pos,
+            [],
+            [],
+            [],
+            [],
+        )
 
 
 def refresh_qbo_access(client_id: str, client_secret: str, refresh_token: str):
-    """Return a new access token and refresh token for QuickBooks."""
-    auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
-    data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
-    resp = requests.post(
-        "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
-        auth=auth,
-        data=data,
-        timeout=10,
+    """Wrapper to refresh a QBO token without instantiating a client."""
+    client = QBOClient(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+        realm_id="",
     )
-    resp.raise_for_status()
-    tokens = resp.json()
-    return tokens.get("access_token"), tokens.get("refresh_token")
+    return client.refresh_access()
 
 
 def qbo_api_url(realm_id: str, path: str, environment: str = "prod") -> str:
-    """Return API base URL for QuickBooks."""
-    base = (
-        "https://sandbox-quickbooks.api.intuit.com"
-        if environment == "sandbox"
-        else "https://quickbooks.api.intuit.com"
+    """Wrapper for generating a QBO API URL."""
+    client = QBOClient(
+        client_id="",
+        client_secret="",
+        refresh_token="",
+        realm_id=realm_id,
+        environment=environment,
     )
-    return f"{base}/v3/company/{realm_id}/{path}"
+    return client.api_url(path)
 
 
 def fetch_qbo_api(
@@ -43,55 +137,17 @@ def fetch_qbo_api(
     item_map: dict | None = None,
     fetch_lists: bool = False,
 ):
-    """Return transaction data from QuickBooks."""
-    access_token, new_refresh = refresh_qbo_access(
-        client_id, client_secret, refresh_token
+    """Compatibility wrapper for fetching transactions."""
+    client = QBOClient(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+        realm_id=realm_id,
+        environment=environment,
     )
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
-    query = f"select * from {doc_type} startposition {start_pos} maxresults 1000"
-    url = qbo_api_url(realm_id, "query", environment)
-    resp = requests.post(url, headers=headers, json={"query": query}, timeout=15)
-    resp.raise_for_status()
-    payload = resp.json()
-    docs = payload.get("QueryResponse", {}).get(doc_type, [])
-
-    rows = []
-    lines = []
-    for doc in docs:
-        created = doc.get("TxnDate")
-        doc_id = doc.get("Id") or doc.get("DocNumber")
-        for idx, line in enumerate(doc.get("Line", [])):
-            detail = line.get("SalesItemLineDetail", {})
-            rows.append(
-                {
-                    "created_at": created,
-                    "sku": detail.get("ItemRef", {}).get("value"),
-                    "description": line.get("Description"),
-                    "quantity": detail.get("Qty"),
-                    "price": detail.get("UnitPrice"),
-                    "total": line.get("Amount"),
-                }
-            )
-            lines.append({"doc_id": doc_id, "line_num": idx, "data": line})
-
-    df = pd.DataFrame(rows)
-    next_pos = start_pos + 1000 if len(docs) == 1000 else None
-    item_map = item_map or {}
-    return (
-        df,
-        [],
-        docs,
-        lines,
-        new_refresh,
-        headers,
-        item_map,
-        next_pos,
-        [],
-        [],
-        [],
-        [],
+    return client.fetch_transactions(
+        doc_type=doc_type,
+        start_pos=start_pos,
+        item_map=item_map,
+        fetch_lists=fetch_lists,
     )

--- a/utils/shopify_api.py
+++ b/utils/shopify_api.py
@@ -2,64 +2,95 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pandas as pd
 import requests
+
+
+@dataclass
+class ShopifyClient:
+    """Simple Shopify API client."""
+
+    domain: str
+    token: str
+
+    def fetch_orders(
+        self,
+        *,
+        since: str | None = None,
+        next_url: str | None = None,
+    ):
+        """Return order data and pagination cursor from the Shopify API."""
+        base = f"https://{self.domain}/admin/api/2023-07"
+        headers = {"X-Shopify-Access-Token": self.token}
+
+        if next_url:
+            url = next_url
+            params = None
+        else:
+            url = f"{base}/orders.json"
+            params = {"limit": 250, "status": "any"}
+            if since:
+                params["created_at_min"] = since
+        resp = requests.get(url, headers=headers, params=params, timeout=15)
+        resp.raise_for_status()
+        payload = resp.json()
+        orders = payload.get("orders", [])
+
+        rows = []
+        line_items = []
+        for order in orders:
+            order_id = order.get("id")
+            created_at = order.get("created_at")
+            for idx, item in enumerate(order.get("line_items", [])):
+                rows.append(
+                    {
+                        "created_at": created_at,
+                        "sku": item.get("sku"),
+                        "description": item.get("name"),
+                        "quantity": item.get("quantity"),
+                        "price": item.get("price"),
+                        "total": float(item.get("price", 0))
+                        * float(item.get("quantity", 0)),
+                    }
+                )
+                line_items.append({"order_id": order_id, "line_num": idx, "data": item})
+
+        df = pd.DataFrame(rows)
+        next_cursor = resp.links.get("next", {}).get("url")
+        return df, orders, line_items, next_cursor
+
+    def fetch_list(
+        self,
+        endpoint: str,
+        key: str,
+        *,
+        since: str | None = None,
+    ):
+        """Return a list of records from a Shopify collection endpoint."""
+        base = f"https://{self.domain}/admin/api/2023-07/{endpoint}.json"
+        headers = {"X-Shopify-Access-Token": self.token}
+        params = {"limit": 250}
+        if since:
+            params["updated_at_min"] = since
+        resp = requests.get(base, headers=headers, params=params, timeout=15)
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload.get(key, []), resp.links.get("next", {}).get("url")
 
 
 def fetch_shopify_api(
     domain: str, token: str, *, since: str | None = None, next_url: str | None = None
 ):
-    """Return order data and pagination cursor from the Shopify API."""
-    base = f"https://{domain}/admin/api/2023-07"
-    headers = {"X-Shopify-Access-Token": token}
-
-    if next_url:
-        url = next_url
-        params = None
-    else:
-        url = f"{base}/orders.json"
-        params = {"limit": 250, "status": "any"}
-        if since:
-            params["created_at_min"] = since
-    resp = requests.get(url, headers=headers, params=params, timeout=15)
-    resp.raise_for_status()
-    payload = resp.json()
-    orders = payload.get("orders", [])
-
-    rows = []
-    line_items = []
-    for order in orders:
-        order_id = order.get("id")
-        created_at = order.get("created_at")
-        for idx, item in enumerate(order.get("line_items", [])):
-            rows.append(
-                {
-                    "created_at": created_at,
-                    "sku": item.get("sku"),
-                    "description": item.get("name"),
-                    "quantity": item.get("quantity"),
-                    "price": item.get("price"),
-                    "total": float(item.get("price", 0))
-                    * float(item.get("quantity", 0)),
-                }
-            )
-            line_items.append({"order_id": order_id, "line_num": idx, "data": item})
-
-    df = pd.DataFrame(rows)
-    next_cursor = resp.links.get("next", {}).get("url")
-    return df, orders, line_items, next_cursor
+    """Compatibility wrapper for fetching Shopify orders."""
+    client = ShopifyClient(domain, token)
+    return client.fetch_orders(since=since, next_url=next_url)
 
 
 def fetch_shopify_list(
     domain: str, token: str, endpoint: str, key: str, *, since: str | None = None
 ):
-    """Return a list of records from a Shopify collection endpoint."""
-    base = f"https://{domain}/admin/api/2023-07/{endpoint}.json"
-    headers = {"X-Shopify-Access-Token": token}
-    params = {"limit": 250}
-    if since:
-        params["updated_at_min"] = since
-    resp = requests.get(base, headers=headers, params=params, timeout=15)
-    resp.raise_for_status()
-    payload = resp.json()
-    return payload.get(key, []), resp.links.get("next", {}).get("url")
+    """Compatibility wrapper for fetching Shopify lists."""
+    client = ShopifyClient(domain, token)
+    return client.fetch_list(endpoint, key, since=since)


### PR DESCRIPTION
## Summary
- turn Shopify, QuickBooks, and HubSpot helpers into lightweight clients
- keep compatibility wrapper functions
- document API connector pattern in the README

## Testing
- `python -m py_compile app.py database.py`


------
https://chatgpt.com/codex/tasks/task_e_685d3935dec48327b785ef9fe5867345