### PR TITLE
Fix traffic metric labels not defined

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,6 +156,13 @@ TRAFFIC_SOURCES = [
     "Paid Search",
 ]
 
+# Labels used to render HubSpot traffic metrics tables
+TRAFFIC_METRIC_LABELS = {
+    "sessions": "Sessions",
+    "avg_time": "Avg Time (min)",
+    "bounce_rate": "Bounce Rate %",
+}
+
 # Map HubSpot API source identifiers to display names
 HUBSPOT_SOURCE_MAP = {
     "EMAIL_MARKETING": "Email Marketing",


### PR DESCRIPTION
## Summary
- define `TRAFFIC_METRIC_LABELS` constant used for HubSpot traffic matrix

## Testing
- `python -m py_compile app.py database.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_685d3b762ac083279488428fc61872ae