### PR TITLE
Add master field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Ultrasuite is a Flask application for aggregating sales data. Upload transaction
 - **Report Options** – Choose the default tab and how many recent years to display.
 - **Shopify Sync** – Connect to the Shopify API to download transactions.
 - **Raw Orders** – Full Shopify order data is stored for future use.
+- **Master Field Columns** – Synced API data includes `master_*` columns for
+  common fields such as price, quantity and description.
 
 Data is stored locally and charts are generated with Matplotlib.
 

--- a/utils/master_fields.py
+++ b/utils/master_fields.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Utility helpers for mapping synced API fields to master columns."""
+
+from typing import Dict, Mapping
+
+import pandas as pd
+
+# Maps API-specific field names to master labels used across the app.
+FIELD_MAPS: Dict[str, Mapping[str, str]] = {
+    "shopify": {
+        "price": "price",
+        "total": "total",
+        "quantity": "qty",
+        "description": "description",
+        "created_at": "created",
+        "sku": "sku",
+    },
+    "qbo": {
+        "price": "price",
+        "total": "total",
+        "quantity": "qty",
+        "description": "description",
+        "created_at": "created",
+        "sku": "sku",
+    },
+}
+
+
+def apply_master_fields(df: pd.DataFrame, source: str) -> pd.DataFrame:
+    """Return ``df`` with ``master_*`` columns added for ``source``."""
+    mapping = FIELD_MAPS.get(source, {})
+    out = df.copy()
+    for src, master in mapping.items():
+        col = f"master_{master}"
+        if src in out.columns and col not in out.columns:
+            out[col] = out[src]
+    return out

--- a/utils/shopify_api.py
+++ b/utils/shopify_api.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 import pandas as pd
 import requests
 
+from .master_fields import apply_master_fields
+
 
 @dataclass
 class ShopifyClient:
@@ -55,9 +57,16 @@ class ShopifyClient:
                         * float(item.get("quantity", 0)),
                     }
                 )
-                line_items.append({"order_id": order_id, "line_num": idx, "data": item})
+                line_items.append(
+                    {
+                        "order_id": order_id,
+                        "line_num": idx,
+                        "data": item,
+                    }
+                )
 
         df = pd.DataFrame(rows)
+        df = apply_master_fields(df, "shopify")
         next_cursor = resp.links.get("next", {}).get("url")
         return df, orders, line_items, next_cursor
 
@@ -81,7 +90,11 @@ class ShopifyClient:
 
 
 def fetch_shopify_api(
-    domain: str, token: str, *, since: str | None = None, next_url: str | None = None
+    domain: str,
+    token: str,
+    *,
+    since: str | None = None,
+    next_url: str | None = None,
 ):
     """Compatibility wrapper for fetching Shopify orders."""
     client = ShopifyClient(domain, token)
@@ -89,7 +102,12 @@ def fetch_shopify_api(
 
 
 def fetch_shopify_list(
-    domain: str, token: str, endpoint: str, key: str, *, since: str | None = None
+    domain: str,
+    token: str,
+    endpoint: str,
+    key: str,
+    *,
+    since: str | None = None,
 ):
     """Compatibility wrapper for fetching Shopify lists."""
     client = ShopifyClient(domain, token)


### PR DESCRIPTION
## Summary
- rename canonical field helpers to use `master_` columns
- update Shopify and QBO clients to produce master field columns
- document master fields in the project features list

## Testing
- `flake8 utils/master_fields.py utils/qbo_api.py utils/shopify_api.py | head -n 20`
- `python -m py_compile app.py database.py utils/qbo_api.py utils/shopify_api.py utils/master_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_685d437dc7ac8327813005e459189530